### PR TITLE
buildd: fix "Lockfiles must be given as absolute path names" error

### DIFF
--- a/cmd/buildd/main.go
+++ b/cmd/buildd/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containerd/containerd/sys"
@@ -44,13 +45,17 @@ func main() {
 
 		server := grpc.NewServer(debugGrpcErrors())
 
-		root := c.GlobalString("root")
+		// relative path does not work with nightlyone/lockfile
+		root, err := filepath.Abs(c.GlobalString("root"))
+		if err != nil {
+			return err
+		}
 
 		if err := os.MkdirAll(root, 0700); err != nil {
 			return errors.Wrapf(err, "failed to create %s", root)
 		}
 
-		controller, err := newController(c)
+		controller, err := newController(c, root)
 		if err != nil {
 			return err
 		}

--- a/cmd/buildd/main_containerd.go
+++ b/cmd/buildd/main_containerd.go
@@ -17,8 +17,8 @@ func appendFlags(f []cli.Flag) []cli.Flag {
 	}...)
 }
 
-func newController(c *cli.Context) (*control.Controller, error) {
-	root := c.GlobalString("root")
+// root must be an absolute path
+func newController(c *cli.Context, root string) (*control.Controller, error) {
 	socket := c.GlobalString("containerd")
 
 	return control.NewContainerd(root, socket)

--- a/cmd/buildd/main_standalone.go
+++ b/cmd/buildd/main_standalone.go
@@ -11,8 +11,7 @@ func appendFlags(f []cli.Flag) []cli.Flag {
 	return f
 }
 
-func newController(c *cli.Context) (*control.Controller, error) {
-	root := c.GlobalString("root")
-
+// root must be an absolute path
+func newController(c *cli.Context, root string) (*control.Controller, error) {
 	return control.NewStandalone(root)
 }

--- a/cmd/buildd/main_unsupported.go
+++ b/cmd/buildd/main_unsupported.go
@@ -13,6 +13,6 @@ func appendFlags(f []cli.Flag) []cli.Flag {
 	return f
 }
 
-func newController(c *cli.Context) (*control.Controller, error) {
+func newController(c *cli.Context, root string) (*control.Controller, error) {
 	return nil, errors.New("invalid build")
 }


### PR DESCRIPTION
Tested with the standalone controller.
Without this patch, the daemon fails to build an image:

    ERRO[0008] /control.Control/Solve returned error: Lockfiles must be
    given as absolute path names
    error creating lockfile
    .buildstate/content/ingest/b8bc9e0954dc1413b6ffd69c106a1d8967130398f50626b5c5a098c5149b0bf3/lock
    github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/content.(*store).ingestPaths
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/content/store.go:369
    github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/content.(*store).Writer
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/content/store.go:233
    github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/remotes.fetch
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/remotes/handlers.go:60
    github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/remotes.FetchHandler.func1
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/remotes/handlers.go:50
    github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/images.HandlerFunc.Handle
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/images/handlers.go:33
    github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/images.Handlers.func1
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/images/handlers.go:43
    github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/images.HandlerFunc.Handle
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/images/handlers.go:33
    github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/images.Dispatch.func1
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/github.com/containerd/containerd/images/handlers.go:103
    github.com/tonistiigi/buildkit_poc/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1
            /home/suda/gopath/src/github.com/tonistiigi/buildkit_poc/vendor/golang.org/x/sync/errgroup/errgroup.go:58
    runtime.goexit
            /usr/local/go/src/runtime/asm_amd64.s:2197

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>