### PR TITLE
buildctl: add dump

### DIFF
--- a/cmd/buildctl/dump.go
+++ b/cmd/buildctl/dump.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/davecgh/go-spew/spew"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/buildkit_poc/client/llb"
+	"github.com/tonistiigi/buildkit_poc/solver/pb"
+	"github.com/urfave/cli"
+)
+
+var dumpCommand = cli.Command{
+	Name:   "dump",
+	Usage:  "dump LLB in human-readable format. LLB must be passed via stdin. This command does not require the daemon to be running.",
+	Action: dumpLLB,
+}
+
+func dumpLLB(clicontext *cli.Context) error {
+	ops, err := loadLLB(os.Stdin)
+	if err != nil {
+		return err
+	}
+	log.Print(spew.Sdump(ops))
+	return nil
+}
+
+type llbOp struct {
+	Op     pb.Op
+	Digest digest.Digest
+}
+
+func loadLLB(r io.Reader) ([]llbOp, error) {
+	bs, err := llb.ReadFrom(r)
+	if err != nil {
+		return nil, err
+	}
+	var ops []llbOp
+	for _, dt := range bs {
+		var op pb.Op
+		if err := (&op).Unmarshal(dt); err != nil {
+			return nil, errors.Wrap(err, "failed to parse op")
+		}
+		dgst := digest.FromBytes(dt)
+		ops = append(ops, llbOp{Op: op, Digest: dgst})
+	}
+	return ops, nil
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -29,6 +29,7 @@ func main() {
 	app.Commands = []cli.Command{
 		diskUsageCommand,
 		buildCommand,
+		dumpCommand,
 	}
 
 	app.Before = func(context *cli.Context) error {


### PR DESCRIPTION
The last PR today 😄 

Example output:
```console
$ go run examples/llboput/example.go > a.llb
$ buildctl dump < a.llb
2017/06/12 09:51:52 ([]main.llbOp) (len=4 cap=4) {
 (main.llbOp) {
  Op: (pb.Op) &Op{Inputs:[],Op:&Op_Source{Source:&SourceOp{Identifier:docker-image://docker.io/library/busybox:latest,},},},
  Digest: (digest.Digest) (len=71) sha256:74ecb5d790c33a213ba00f8f43d62947df1d4dea72f5ec13353a9b943f469f0f
 },
 (main.llbOp) {
  Op: (pb.Op) &Op{Inputs:[&Input{Digest:sha256:74ecb5d790c33a213ba00f8f43d62947df1d4dea72f5ec13353a9b943f469f0f,Index:0,}],Op:&Op_Exec{Exec:&ExecOp{Meta:&Meta{Args:[/bin/sleep 1],Env:[],Cwd:/,},Mounts:[&Mount{Input:0,Selector:,Dest:/,Output:0,}],},},},
  Digest: (digest.Digest) (len=71) sha256:1de5701b93648843bf2cf6ebf982b4f63ea55dcb9259e73a5bd6737505660d06
 },
 (main.llbOp) {
  Op: (pb.Op) &Op{Inputs:[&Input{Digest:sha256:1de5701b93648843bf2cf6ebf982b4f63ea55dcb9259e73a5bd6737505660d06,Index:0,}],Op:&Op_Exec{Exec:&ExecOp{Meta:&Meta{Args:[/bin/sh -c echo foo > /bar],Env:[],Cwd:/,},Mounts:[&Mount{Input:0,Selector:,Dest:/,Output:0,}],},},},
  Digest: (digest.Digest) (len=71) sha256:dcfef0f97703c4df76cba8f40891d2a851ae78d3bedce839e43e2e505e691341
 },
 (main.llbOp) {
  Op: (pb.Op) &Op{Inputs:[&Input{Digest:sha256:dcfef0f97703c4df76cba8f40891d2a851ae78d3bedce839e43e2e505e691341,Index:0,}],Op:&Op_Exec{Exec:&ExecOp{Meta:&Meta{Args:[/bin/ls -l /],Env:[],Cwd:/,},Mounts:[&Mount{Input:0,Selector:,Dest:/,Output:0,}],},},},
  Digest: (digest.Digest) (len=71) sha256:cec673a11a7de1687f9626850bfbd802ee8fe964e9b07f2ebbb365ae650fab09
 }
}
```

I'm also planning graphviz output (`buildctl dump --mode dot`)  in another PR.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>