### PR TITLE
buildctl: use json for debugging

### DIFF
--- a/cmd/buildctl/debug/dump.go
+++ b/cmd/buildctl/debug/dump.go
@@ -1,11 +1,10 @@
 package debug
 
 import (
+	"encoding/json"
 	"io"
-	"log"
 	"os"
 
-	"github.com/davecgh/go-spew/spew"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/buildkit_poc/client/llb"
@@ -24,7 +23,12 @@ func dumpLLB(clicontext *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Print(spew.Sdump(ops))
+	enc := json.NewEncoder(os.Stdout)
+	for _, op := range ops {
+		if err := enc.Encode(op); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
JSON seems much more readable. Problem is that it needs to be manually piped to `jq`.

@AkihiroSuda 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>